### PR TITLE
replace a deprecated item

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ macro_rules! AppInstance
     (__FnBody $t: ty = $e: expr) =>
     {{
         static mut OBJ: *mut $t = 0 as *mut _;
-        static INIT: ::std::sync::Once = ::std::sync::ONCE_INIT;
+        static INIT: ::std::sync::Once = ::std::sync::Once::new();
         extern "C" fn dropper() { unsafe { ::std::mem::drop(Box::from_raw(OBJ)); } }
 
         INIT.call_once(|| unsafe { OBJ = Box::into_raw(Box::new($e)); ::libc::atexit(dropper); });


### PR DESCRIPTION
replace a deprecated item '::std::sync::ONCE_INIT' with '::std::sync::Once::new()'